### PR TITLE
Fix OTP email runtime error with SMTP config check

### DIFF
--- a/app/api/send-otp/route.ts
+++ b/app/api/send-otp/route.ts
@@ -50,6 +50,7 @@ export async function POST(request: NextRequest) {
     const res = NextResponse.json({
       success: true,
       message: "OTP sent successfully",
+      emailDispatched,
       otp: process.env.NODE_ENV === "development" ? otp : undefined,
     })
 


### PR DESCRIPTION
## Purpose
Fix a runtime error that was occurring in the OTP email sending functionality by adding proper SMTP configuration validation and graceful error handling.

## Code changes
- Added SMTP configuration validation using `isTruthy` helper function to check for required environment variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`/`EMAIL_FROM`)
- Implemented graceful handling when SMTP is not configured:
  - Logs a warning message instead of failing
  - Skips email dispatch but continues with OTP generation
- Added environment-aware error handling that only fails in production when email sending fails
- Added `emailDispatched` flag to the response to indicate whether the email was actually sent
- Maintained existing development mode behavior where OTP is included in response

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c9489ba587374bdea3b1e9ef588a7fed/echo-sanctuary)

👀 [Preview Link](https://c9489ba587374bdea3b1e9ef588a7fed-echo-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c9489ba587374bdea3b1e9ef588a7fed</projectId>-->
<!--<branchName>echo-sanctuary</branchName>-->